### PR TITLE
installed rubocop and made minor adjustment to spec file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
+# Rubocop enforces ruby style guidelines
+gem 'rubocop', require: false
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.0.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     arel (4.0.2)
+    ast (2.3.0)
     builder (3.1.4)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -52,8 +53,11 @@ GEM
     mime-types (1.25.1)
     minitest (4.7.5)
     multi_json (1.12.1)
+    parser (2.3.1.2)
+      ast (~> 2.2)
     pg (0.18.4)
     polyglot (0.3.5)
+    powerpack (0.1.1)
     rack (1.5.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -75,6 +79,7 @@ GEM
       activesupport (= 4.0.4)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.1.0)
     rake (11.2.2)
     rdoc (4.2.2)
       json (~> 1.4)
@@ -95,6 +100,13 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    rubocop (0.41.1)
+      parser (>= 2.3.1.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
@@ -125,6 +137,7 @@ GEM
     tzinfo (0.3.50)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.1.0)
 
 PLATFORMS
   ruby
@@ -137,6 +150,7 @@ DEPENDENCIES
   rails (= 4.0.4)
   rails_12factor
   rspec-rails (~> 3.0)
+  rubocop
   sass-rails (~> 4.0.2)
   sdoc
   turbolinks

--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe StaticPagesController, type: :controller do
 		it "should show the landing page" do
 			get :index
 			expect(response).to have_http_status(:success)
-           end
-          end 
+    end
+  end 
 end


### PR DESCRIPTION
I added the rubocop gem to the gemfile using this very simple to follow guide: http://rubocop.readthedocs.io/en/latest/

To play around with rubocop, first run bundle install
Then make sure to exit your current [Web Dev] environment and make a new [Web Dev] environment
The nicest output happens when you run the command 'rubocop --format simple'

It will return a lot of errors from standard rails code so ignore that
I made adjustments in the static_pages_controller_spec.rb file for proper spacing